### PR TITLE
FIX | Don't listen for error chan on ReadEvent

### DIFF
--- a/eventsocket/eventsocket.go
+++ b/eventsocket/eventsocket.go
@@ -261,16 +261,13 @@ func (h *Connection) Close() {
 // When subscribing to events (e.g. `Send("events json ALL")`) it makes no
 // difference to use plain or json. ReadEvent will parse them and return
 // all headers and the body (if any) in an Event struct.
-func (h *Connection) ReadEvent() (*Event, error) {
+func (h *Connection) ReadEvent() *Event {
 	var (
-		ev  *Event
-		err error
+		ev *Event
 	)
 	select {
-	case err = <-h.err:
-		return nil, err
 	case ev = <-h.evt:
-		return ev, nil
+		return ev
 	}
 }
 

--- a/eventsocket/eventsocket.go
+++ b/eventsocket/eventsocket.go
@@ -173,7 +173,7 @@ func (h *Connection) readOne() bool {
 		length, err = strconv.Atoi(v)
 		if err == nil {
 			b := make([]byte, length)
-			if _, err = io.ReadFull(h.reader, b); err != nil {
+			if _, err = io.ReadFull(h.reader, b); err == nil {
 				resp.Body = string(b)
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module eventsocket/v1
+
+go 1.14


### PR DESCRIPTION
- Error from FreeSwitch is received on `err` chan.
- `ExecuteUUID` (sendMsg) and `ReadEvent` both tries to read from `err` chan
- `ReadEvent` reads the error from `err` chan and `ExecuteUUID` keeps on waiting

![{3B233558-2C59-4F6C-9186-F8EF536229FE}](https://user-images.githubusercontent.com/9738956/95070637-08a33f00-0726-11eb-9a01-4aa81c2cc528.jpg)
